### PR TITLE
Fixed bugs in predicate cashe and create.

### DIFF
--- a/easel/predicate.lua
+++ b/easel/predicate.lua
@@ -1,44 +1,43 @@
 local M = {}
 
-
 local predicates = {}
-
-
-
--- create a predicate
--- this will cache the predicate and return the same one if requested more than
--- once
-function M.create(tags)
-	for i,tag in ipairs(tags) do
-		tag = type(tag) == "string" and hash(tag) or tag
-	end
-
+local function find_pred(hashed_list)
 	for _,predicate in ipairs(predicates) do
-		local found_predicate = true
-		for _,tag in ipairs(tags) do
-			if not predicate.tags_lut[tag] then
-				found_predicate = false
-				break
+        local found_predicate = false
+        if #predicate == #hashed_list then
+            found_predicate = true
+ 	    	for __,tag in ipairs(hashed_list) do
+		    	if not predicate.tags_lut[tag] then
+				    found_predicate = false
+				    break
+                end
 			end
 		end
-		if found_predicate then
-			return predicate.handle
-		end
-	end
-
-	local predicate = {
-		tags_lut = {},
-		handle = render.predicate(tags),
-	}
-	for _,tag in ipairs(tags) do
-		predicate.tags_lut[tag] = true
-	end
-
-	predicates[#predicates + 1] = predicate
-	return predicate.handle
+		if found_predicate then return predicate end
+    end
 end
-
-
-
-
+local function add_pred(hashed_tags)
+      	local new_predicate = {
+		tags_lut = {},
+		handle = render.predicate(hashed_tags),
+    	}
+    	for _,tag in ipairs(hashed_tags) do
+	    	new_predicate.tags_lut[tag] = true
+    	end
+    	predicates[#predicates + 1] = new_predicate
+end
+ 
+function M.create(tags)
+	local hashed_tags = {}
+	for k,v in ipairs(tags) do
+		hashed_tags[k] = hash(tags[k])
+	end	
+    local existing_pred = find_pred(hashed_tags)
+       if existing_pred then
+        return existing_pred.handle
+       else
+        add_pred(hashed_tags)
+        return predicates[#predicates].handle
+       end
+end 
 return M

--- a/easel/predicate.lua
+++ b/easel/predicate.lua
@@ -3,41 +3,43 @@ local M = {}
 local predicates = {}
 local function find_pred(hashed_list)
 	for _,predicate in ipairs(predicates) do
-        local found_predicate = false
-        if #predicate == #hashed_list then
-            found_predicate = true
- 	    	for __,tag in ipairs(hashed_list) do
-		    	if not predicate.tags_lut[tag] then
-				    found_predicate = false
-				    break
-                end
+		local found_predicate = false
+		if #predicate == #hashed_list then
+			found_predicate = true
+			for __,tag in ipairs(hashed_list) do
+				if not predicate.tags_lut[tag] then
+					found_predicate = false
+					break
+				end
 			end
 		end
 		if found_predicate then return predicate end
-    end
+	end
 end
+
 local function add_pred(hashed_tags)
-      	local new_predicate = {
+	local new_predicate = {
 		tags_lut = {},
 		handle = render.predicate(hashed_tags),
-    	}
-    	for _,tag in ipairs(hashed_tags) do
-	    	new_predicate.tags_lut[tag] = true
-    	end
-    	predicates[#predicates + 1] = new_predicate
+	}
+	for _,tag in ipairs(hashed_tags) do
+		new_predicate.tags_lut[tag] = true
+	end
+	predicates[#predicates + 1] = new_predicate
 end
- 
+
 function M.create(tags)
 	local hashed_tags = {}
 	for k,v in ipairs(tags) do
 		hashed_tags[k] = hash(tags[k])
 	end	
-    local existing_pred = find_pred(hashed_tags)
-       if existing_pred then
-        return existing_pred.handle
-       else
-        add_pred(hashed_tags)
-        return predicates[#predicates].handle
-       end
+	local existing_pred = find_pred(hashed_tags)
+	if existing_pred then
+		return existing_pred.handle
+	else
+		add_pred(hashed_tags)
+		return predicates[#predicates].handle
+	end
 end 
+
 return M


### PR DESCRIPTION
Strings were not being hashed, fixed this, although this did not matter as render.predicate() works on non-hashed strings.

When checking for existing predicates the code did not check if there were more tags defined than given,
 eg {"b"} matched {"a","b"}.